### PR TITLE
Support for certbot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     restart: always
     build: ./nginx
     image: tidr/apiexplorer_nginx
+    volumes:
+    - nginx-www:/usr/share/nginx:rw
+    - certs:/etc/ssl/certs:rw
     ports:
       - "443:443"
       - "80:80"
@@ -26,3 +29,5 @@ services:
 
 volumes:
   db:
+  certs:
+  nginx-www:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,8 +1,15 @@
 FROM nginx:stable
-
+ARG APPFQDN
+ARG APPEIP
+ENV x_APPFQDN=${APPFQDN}
+ENV x_APPEIP=${APPEIP}
+RUN if [ "x$x_APPFQDN" = "x" ]; then export CN=apiexplorer; else export CN=${x_APPFQDN}; fi; echo -n ${CN} > /tmp/cn.txt
+RUN if [ "x$x_APPEIP" = "x" ]; then export IP=127.0.0.1; else export IP=${x_APPEIP}; fi; echo -n ${IP} > /tmp/ip.txt
 RUN apt-get update && apt-get install openssl
 RUN openssl genrsa -out /etc/ssl/certs/apiexplorer.key 4096
-RUN openssl req -new -x509 -key /etc/ssl/certs/apiexplorer.key -sha256 -out /etc/ssl/certs/apiexplorer.crt -days 1095 -subj "/C=US/ST=California/L=Santa Clara/O=Palo Alto Networks/OU= Developer Relations/CN=apiexplorer"
-
+RUN cp /etc/ssl/openssl.cnf /tmp/openssl.cnf
+RUN IP=$(cat /tmp/ip.txt); CN=$(cat /tmp/cn.txt); printf "[SAN]\nsubjectAltName=DNS:${CN},IP:${IP}\n" >> /tmp/openssl.cnf
+RUN CN=$(cat /tmp/cn.txt); openssl req -new -x509 -key /etc/ssl/certs/apiexplorer.key -sha256 -out /etc/ssl/certs/apiexplorer.crt -days 1095 -subj "/C=US/ST=California/L=Santa Clara/O=Palo Alto Networks/OU= Developer Relations/CN=${CN}" -extensions SAN -config /tmp/openssl.cnf
 COPY nginx.conf /etc/nginx/nginx.conf
-
+COPY copy_certs.sh /etc/ssl/certs/copy_certs.sh
+RUN chmod +x /etc/ssl/certs/copy_certs.sh

--- a/nginx/copy_certs.sh
+++ b/nginx/copy_certs.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+if [ -d  "$RENEWED_LINEAGE" ]; then
+  cp -La $RENEWED_LINEAGE/fullchain.pem $RENEWED_LINEAGE/privkey.pem /etc/ssl/certs
+  cd /etc/ssl/certs
+  if [ -r ./fullchain.pem ]; then
+    mv apiexplorer.crt apiexplorer.crt.orig
+    ln -s fullchain.pem  apiexplorer.crt
+  fi
+  if [ -r privkey.pem ]; then
+    mv apiexplorer.key apiexplorer.key.orig
+    ln -s privkey.pem  apiexplorer.key
+  fi
+fi

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -51,7 +51,7 @@ http {
             if ($request_method !~ ^(GET|DELETE|POST|PUT)$ ) {
                 return    444;
             }
-            root /var/www/letsencrypt;
+            root /usr/share/nginx/html;
         }
 
         location / {


### PR DESCRIPTION
Support for certbot (generation of Letsencrypt certificates):
* Reverted nginx www directory to /usr/share/nginx/www
* Added copy script to update certificates generated by certbot as a hook script
* Separated volumes for nginx root and /etc/ssl/certs
* Updated Dockerfile to allow IP and FQDN in SAN for self signed cert generation
